### PR TITLE
Fix BPM references and add detail rendering test

### DIFF
--- a/auto_hear.py
+++ b/auto_hear.py
@@ -615,20 +615,20 @@ Muestras: {self.analysis_results['audio_info']['samples']:,}"""
         details += f"BPM Final: {bpm_data['bpm']:.2f}\n"
         details += f"Confianza: {bpm_data['confidence']:.4f} ({bpm_data['confidence']*100:.1f}%)\n"
         details += f"Método principal: {bpm_data['method']}\n"
-        details += f"Beats detectados: {bmp_data['beats_detected']}\n"
-        
-        if 'tempo_stability' in bmp_data and bmp_data['tempo_stability'] is not None:
-            details += f"Estabilidad del tempo: {bmp_data['tempo_stability']:.4f}\n"
-            if bmp_data['tempo_stability'] < 0.2:
+        details += f"Beats detectados: {bpm_data['beats_detected']}\n"
+
+        if 'tempo_stability' in bpm_data and bpm_data['tempo_stability'] is not None:
+            details += f"Estabilidad del tempo: {bpm_data['tempo_stability']:.4f}\n"
+            if bpm_data['tempo_stability'] < 0.2:
                 details += "  -> Tempo muy estable\n"
-            elif bmp_data['tempo_stability'] < 0.4:
+            elif bpm_data['tempo_stability'] < 0.4:
                 details += "  -> Tempo moderadamente variable\n"
             else:
                 details += "  -> Tempo muy variable (cambios frecuentes)\n"
-        
+
         details += "\nTodas las estimaciones BPM:\n"
-        for i, est in enumerate(bmp_data.get('all_estimates', []), 1):
-            details += f"  {i}. {est['bmp']:.2f} BPM (confianza: {est['confidence']:.3f}, método: {est['method']})\n"
+        for i, est in enumerate(bpm_data.get('all_estimates', []), 1):
+            details += f"  {i}. {est['bpm']:.2f} BPM (confianza: {est['confidence']:.3f}, método: {est['method']})\n"
         
         # Análisis de tonalidad detallado
         key_data = self.analysis_results['key_analysis']
@@ -713,7 +713,7 @@ Muestras: {self.analysis_results['audio_info']['samples']:,}"""
                         f.write(f"Duración: {self.analysis_results['duration']:.2f}s\n\n")
                         
                         f.write("RESULTADOS PRINCIPALES:\n")
-                        f.write(f"BPM: {self.analysis_results['bmp_analysis']['bmp']:.1f}\n")
+                        f.write(f"BPM: {self.analysis_results['bpm_analysis']['bpm']:.1f}\n")
                         f.write(f"Tonalidad: {self.analysis_results['key_analysis']['key']} {self.analysis_results['key_analysis']['scale']}\n\n")
                         
                         f.write("DETALLES COMPLETOS:\n")
@@ -731,16 +731,16 @@ Muestras: {self.analysis_results['audio_info']['samples']:,}"""
             return
         
         try:
-            bmp_data = self.analysis_results['bmp_analysis']
+            bpm_data = self.analysis_results['bpm_analysis']
             key_data = self.analysis_results['key_analysis']
-            
+
             clipboard_text = f"""Análisis Musical - {os.path.basename(self.analysis_results['file_path'])}
 
-BPM: {bmp_data['bmp']:.1f} (confianza: {bmp_data['confidence']*100:.1f}%)
+BPM: {bpm_data['bpm']:.1f} (confianza: {bpm_data['confidence']*100:.1f}%)
 Tonalidad: {key_data['key']} {key_data['scale']} (confianza: {key_data['confidence']*100:.1f}%)
 Duración: {self.analysis_results['duration']:.2f}s
 
-Método BPM: {bmp_data['method']}
+Método BPM: {bpm_data['method']}
 Método Key: {key_data['method']}"""
             
             self.root.clipboard_clear()

--- a/music_analyzer.py
+++ b/music_analyzer.py
@@ -86,21 +86,8 @@ class MusicAnalyzer:
                 "beats_detected": int(len(beats)),
                 "beats": beats.tolist(),
                 "all_estimates": [
-                    {"bmp": float(tempo), "confidence": 1.0, "method": "librosa"}
+                    {"bpm": float(tempo), "confidence": 1.0, "method": "librosa"}
                 ],
-            }
-
-            # ``auto_hear`` references ``bmp_analysis`` in a few places due to
-            # a typo; we therefore provide a mirror of the BPM information
-            # under that key to avoid ``KeyError`` exceptions.
-            bmp_analysis = {
-                "bmp": bpm_analysis["bpm"],
-                "confidence": bpm_analysis["confidence"],
-                "method": bpm_analysis["method"],
-                "tempo_stability": bpm_analysis["tempo_stability"],
-                "beats_detected": bpm_analysis["beats_detected"],
-                "beats": bpm_analysis["beats"],
-                "all_estimates": bpm_analysis["all_estimates"],
             }
 
             # ---- Key analysis -------------------------------------------------
@@ -179,7 +166,6 @@ class MusicAnalyzer:
                 "duration": duration,
                 "audio_info": audio_info,
                 "bpm_analysis": bpm_analysis,
-                "bmp_analysis": bmp_analysis,
                 "key_analysis": key_analysis,
                 "silence_analysis": silence_analysis,
             }

--- a/tests/test_details_render.py
+++ b/tests/test_details_render.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from auto_hear import MusicAnalyzerGUI
+
+
+class DummyText:
+    def __init__(self):
+        self.content = ""
+
+    def config(self, **kwargs):
+        pass
+
+    def delete(self, *args, **kwargs):
+        self.content = ""
+
+    def insert(self, *args):
+        text = args[-1] if args else ""
+        self.content += text
+
+    def get(self, *args, **kwargs):
+        return self.content
+
+
+class DummyVar:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+def _make_app():
+    app = MusicAnalyzerGUI.__new__(MusicAnalyzerGUI)
+    app.details_text = DummyText()
+    app.silence_threshold_var = DummyVar(-40)
+    app.min_silence_var = DummyVar(0.5)
+    app.analysis_results = {
+        "file_path": "dummy.wav",
+        "duration": 1.23,
+        "audio_info": {"sample_rate": 44100, "samples": 12345},
+        "bpm_analysis": {
+            "bpm": 120.0,
+            "confidence": 0.9,
+            "method": "test",
+            "tempo_stability": 0.3,
+            "beats_detected": 10,
+            "beats": [],
+            "all_estimates": [
+                {"bpm": 120.0, "confidence": 0.9, "method": "test"}
+            ],
+        },
+        "key_analysis": {
+            "key": "C",
+            "scale": "major",
+            "confidence": 0.8,
+            "method": "test",
+            "key_stability": 0.9,
+            "key_changes_detected": False,
+        },
+        "silence_analysis": {
+            "segments_found": 0,
+            "segments": [],
+            "total_silence_duration": 0.0,
+        },
+    }
+    return app
+
+
+def test_update_details_display_renders_without_error():
+    app = _make_app()
+    app.update_details_display()
+    content = app.details_text.get()
+    assert "=== ANÁLISIS BPM ===" in content


### PR DESCRIPTION
## Summary
- rename `bmp` references to `bpm` and adjust data structures
- update export and clipboard features to use `bpm_analysis`
- add unit test ensuring detail section renders correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a48cd46924832c8953d12dd946552e